### PR TITLE
CollectionLinkHydrator should extend from different AbstractCollectionStrategy

### DIFF
--- a/src/Hydrator/Strategy/CollectionLinkHydratorV3.php
+++ b/src/Hydrator/Strategy/CollectionLinkHydratorV3.php
@@ -8,7 +8,7 @@
 
 namespace Laminas\ApiTools\Doctrine\QueryBuilder\Hydrator\Strategy;
 
-use DoctrineModule\Stdlib\Hydrator\Strategy\AbstractCollectionStrategy;
+use Doctrine\Laminas\Hydrator\Strategy\AbstractCollectionStrategy;
 use Laminas\ApiTools\Hal\Link\Link;
 use Laminas\Filter\FilterChain;
 use Laminas\Hydrator\Strategy\StrategyInterface;

--- a/test/Hydrator/Strategy/CollectionLinkTest.php
+++ b/test/Hydrator/Strategy/CollectionLinkTest.php
@@ -8,7 +8,7 @@
 
 namespace LaminasTest\ApiTools\Doctrine\QueryBuilder\Hydrator\Strategy;
 
-use laminas\apitools\doctrine\querybuilder\hydrator\strategy\collectionlink;
+use Laminas\ApiTools\Doctrine\QueryBuilder\Hydrator\Strategy\Collectionlink;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +22,7 @@ class CollectionLinkTest extends TestCase
     /** @var stdClass|MockObject */
     private $mockValue;
 
-    /** @var collectionlink */
+    /** @var Collectionlink */
     private $hydrator;
 
     public function setUp(): void
@@ -70,7 +70,7 @@ class CollectionLinkTest extends TestCase
         $mock = $this->prophesize(ServiceManager::class);
         $mock->get('config')->willReturn($config);
 
-        $this->hydrator = new collectionlink();
+        $this->hydrator = new Collectionlink();
         $this->hydrator->setServiceManager($mock->reveal());
     }
 


### PR DESCRIPTION
Fixes #13. 

Class `Laminas\ApiTools\Doctrine\QueryBuilder\Hydrator\Strategy\CollectionLinkHydratorV3` should extend class `AbstractCollectionStrategy` of [doctrine/doctrine-laminas-hydrator](https://github.com/doctrine/doctrine-laminas-hydrator/blob/master/src/Strategy/AbstractCollectionStrategy.php#L14) when DoctrineModule >v3 is installed instead of the then removed `AbstractCollectionStrategy` of DoctrineModule v2.

