### PR TITLE
Allow v3 of doctrine/doctrine-orm-module as dev package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "doctrine/dbal": "^2.12.1 || ^3.0.0",
         "doctrine/orm": "^2.7.5",
         "doctrine/doctrine-mongo-odm-module": "^1.0 || ^2.0.2 || ^3.0.2",
-        "doctrine/doctrine-orm-module": "^2.1.3",
+        "doctrine/doctrine-orm-module": "^2.1.3 || ^3.1.1",
         "laminas-api-tools/api-tools-provider": "^1.2",
         "laminas/laminas-coding-standard": "~2.1.4",
         "laminas/laminas-i18n": "^2.7.3",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
### Description

As per the "suggest"ion in the composer.json allow doctrine-orm-module v3 to be installed as dev dependency.

```json
    "suggest": {
        "doctrine/doctrine-mongo-odm-module": "^1.0 || ^2.0.2 || ^3.0.2, if you wish to use the Doctrine ODM",
        "doctrine/doctrine-orm-module": "^2.1.3 || ^3.1.1, if you wish to use the Doctrine ORM",
        "ext/mongo": "Mongo extension, if using ODM"
    },
```