### PR TITLE
Normalize composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "laminas-api-tools/api-tools-doctrine-querybuilder",
     "description": "Laminas API Tools Doctrine QueryBuilder module",
-    "license": "BSD-3-Clause",
     "keywords": [
         "laminas",
         "api-tools",
@@ -10,24 +9,7 @@
         "filter"
     ],
     "homepage": "https://api-tools.getlaminas.org",
-    "support": {
-        "docs": "https://api-tools.getlaminas.org/documentation",
-        "issues": "https://github.com/laminas-api-tools/api-tools-doctrine-querybuilder/issues",
-        "source": "https://github.com/laminas-api-tools/api-tools-doctrine-querybuilder",
-        "rss": "https://github.com/laminas-api-tools/api-tools-doctrine-querybuilder/releases.atom",
-        "chat": "https://laminas.dev/chat",
-        "forum": "https://discourse.laminas.dev"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "laminas": {
-            "module": [
-                "Laminas\\ApiTools\\Doctrine\\QueryBuilder"
-            ]
-        }
-    },
+    "license": "BSD-3-Clause",
     "require": {
         "php": "^7.3 || ~8.0.0",
         "doctrine/doctrine-module": "^2.1.8 || ^3.0.1 || ^4.1.0",
@@ -40,11 +22,14 @@
         "laminas/laminas-servicemanager": "^2.7.6 || ^3.1.1",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
+    "replace": {
+        "zfcampus/zf-doctrine-querybuilder": "^1.8.0"
+    },
     "require-dev": {
         "doctrine/dbal": "^2.12.1 || ^3.0.0",
-        "doctrine/orm": "^2.7.5",
         "doctrine/doctrine-mongo-odm-module": "^1.0 || ^2.0.2 || ^3.0.2",
         "doctrine/doctrine-orm-module": "^2.1.3",
+        "doctrine/orm": "^2.7.5",
         "laminas-api-tools/api-tools-provider": "^1.2",
         "laminas/laminas-coding-standard": "~2.1.4",
         "laminas/laminas-i18n": "^2.7.3",
@@ -60,13 +45,23 @@
         "doctrine/doctrine-orm-module": "^2.1.3 || ^3.1.1, if you wish to use the Doctrine ORM",
         "ext/mongo": "Mongo extension, if using ODM"
     },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "laminas": {
+            "module": [
+                "Laminas\\ApiTools\\Doctrine\\QueryBuilder"
+            ]
+        }
+    },
     "autoload": {
-        "files": [
-            "src/_autoload.php"
-        ],
         "psr-4": {
             "Laminas\\ApiTools\\Doctrine\\QueryBuilder\\": "src/"
-        }
+        },
+        "files": [
+            "src/_autoload.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
@@ -83,7 +78,12 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zfcampus/zf-doctrine-querybuilder": "^1.8.0"
+    "support": {
+        "issues": "https://github.com/laminas-api-tools/api-tools-doctrine-querybuilder/issues",
+        "forum": "https://discourse.laminas.dev",
+        "chat": "https://laminas.dev/chat",
+        "source": "https://github.com/laminas-api-tools/api-tools-doctrine-querybuilder",
+        "docs": "https://api-tools.getlaminas.org/documentation",
+        "rss": "https://github.com/laminas-api-tools/api-tools-doctrine-querybuilder/releases.atom"
     }
 }


### PR DESCRIPTION
**[QA]**
* Normalize `composer.json` and/or update `composer.lock`
    - Restructure `composer.json` according to the underlying [JSON schema](https://getcomposer.org/schema.json).
    - Prevent inconsistencies between all (200+) repositories across all 3 GitHub organizations (`laminas`, `mezzio`, and `laminas-api-tools`).